### PR TITLE
Fixed wrong argument in exclude namespaces normalisation function

### DIFF
--- a/scripts/signature-builder.php
+++ b/scripts/signature-builder.php
@@ -44,7 +44,7 @@ if ($namespaces) {
 
 $excludeNamespaces = getCliOption('exclude-namespaces', 'e');
 if ($excludeNamespaces) {
-    $excludeNamespaces = array_map(fn($namespace) => normalizeNamespace($excludeNamespaces), explode(',', $excludeNamespaces));
+    $excludeNamespaces = array_map(fn($namespace) => normalizeNamespace($namespace), explode(',', $excludeNamespaces));
 }
 
 $filterNamespace = function($class) use ($namespaces, $excludeNamespaces): bool {


### PR DESCRIPTION
### Description

As the arrow function argument is $namespaces, it must be normalised instead of $excludeNamespaces.

### Related issues

