### PR TITLE
update namespace for ValueObject's Visibility class

### DIFF
--- a/sets/craft-cms-50.php
+++ b/sets/craft-cms-50.php
@@ -9,7 +9,7 @@ use Rector\Arguments\Rector\MethodCall\RemoveMethodCallParamRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Arguments\ValueObject\RemoveMethodCallParam;
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\Visibility;
+use Rector\ValueObject\Visibility;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;


### PR DESCRIPTION
### Description
The namespace for the `ValueObject`’s `Visibility` class was [changed](https://github.com/rectorphp/rector/commit/7e7a2f067aa6853381fa7944cb38bd1947144f32#diff-9205c27ce387db0353131700e2273b8db106012d6baa999e3074706439b707b6) in `0.19.0` from `Rector\Core\ValueObject\Visibility` to `Rector\ValueObject\Visibility`.


### Related issues
n/a
