### PR TITLE
Require either Craft 4 or Craft 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "craftcms/cms": "^4.0.0",
+        "craftcms/cms": "^4.0.0|^5.0.0",
         "craftcms/ecs": "dev-main",
         "phpstan/phpstan": "^1.10",
         "symfony/var-exporter": "^6.0"


### PR DESCRIPTION
### Description

Updates the CraftCMS requirement to either Craft 4 or Craft 5

### Related issues

N/A

